### PR TITLE
tools now uses partner link model

### DIFF
--- a/core/templates/base_account.html
+++ b/core/templates/base_account.html
@@ -3,7 +3,7 @@
 {% load Pleio_templatetags %}
 {% load app_customization %}
 {% get_current_language as LANGUAGE_CODE %}
-{% load app_customization %}
+{% load partner_links %}
 
 {% language request.COOKIES.lang %}
 <!DOCTYPE html>
@@ -99,17 +99,7 @@
                                     <div>{% trans "Access your various collaboration tools here:" %}</div>
                                 </div>
                             </div>
-
-                            <div class="ui secondary labeled icon menu">
-                                <a class="item" href="https://gccollab.ca/">
-                                    <img alt="GCcollab" aria-hidden="true" src="/static/images/collab_icon.png" class="app_icon" style="margin-bottom: 5px; padding-right:0;"></img>
-                                    Collab
-                                </a>
-                                <a class="item" href="https://wiki.gccollab.ca/">
-                                    <img alt="GCcollab" aria-hidden="true" src="/static/images/wiki_icon.png" class="app_icon" style="margin-bottom: 5px; padding-right:0;"></img>
-                                    Wiki
-                                </a>
-                            </div>
+                            {% partner_links %}
                         </div>
                     </li>
 

--- a/core/templates/partner_links.html
+++ b/core/templates/partner_links.html
@@ -1,0 +1,8 @@
+<div class="ui secondary labeled icon menu" style="flex-wrap:wrap;">
+    {% for partner in partners %}
+    <a class="item" href="{{partner.partner_site_url}}">
+        <img alt="{{partner.partner_site_name}}" aria-hidden="true" src="{{partner.partner_site_logo_url}}" class="app_icon" style="margin-bottom: 5px; padding-right:0;"></img>
+        {{partner.partner_site_name}}
+    </a>
+    {% endfor %}
+</div>

--- a/core/templatetags/partner_links.py
+++ b/core/templatetags/partner_links.py
@@ -1,0 +1,13 @@
+from django import template
+from core.models import PleioPartnerSite
+from django.core.exceptions import ObjectDoesNotExist
+
+register = template.Library()
+
+@register.inclusion_tag('partner_links.html')
+def partner_links():
+    try:
+        partners = PleioPartnerSite.objects.all()
+        return {'partners':partners}
+    except PleioPartnerSite.DoesNotExist:
+        return ''        

--- a/docker/config.py
+++ b/docker/config.py
@@ -27,7 +27,7 @@ SEND_SUSPICIOUS_BEHAVIOR_WARNINGS = os.getenv('SEND_SUSPICIOUS_BEHAVIOR_WARNINGS
 
 DEFAULT_FROM_EMAIL = os.getenv('FROM_EMAIL')
 
-#EMAIL_BACKEND = 'django.core.mail.backends.dummy.EmailBackend'
+EMAIL_BACKEND = 'django.core.mail.backends.dummy.EmailBackend'
 EMAIL_HOST = os.getenv('EMAIL_HOST')
 EMAIL_PORT = os.getenv('EMAIL_PORT')
 EMAIL_HOST_USER = os.getenv('EMAIL_USER')


### PR DESCRIPTION
Using partner site model to add links to tools on account page instead of hard coded links.