### PR TITLE
Added new view to integrate Freshdesk SSO

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -23,12 +23,10 @@ from two_factor.views.profile import DisableView
 
 from django.http import Http404, HttpResponseRedirect
 from django.views.decorators.cache import never_cache
-from django.utils.encoding import iri_to_uri
 from django.utils.http import urlquote
-from django.core.exceptions import ImproperlyConfigured
+from datetime import datetime
 import hashlib
 import hmac
-from datetime import datetime
 
 def home(request):
     if request.user.is_authenticated():
@@ -230,6 +228,6 @@ def freshdesk_sso(request):
 
     data = '{0}{1}{2}{3}'.format(name, settings.FRESHDESK_SECRET_KEY, email, dt)
     generated_hash = hmac.new(settings.FRESHDESK_SECRET_KEY.encode(), data.encode(), hashlib.md5).hexdigest()
-    url = settings.FRESHDESK_URL+'login/sso/?name='+urlquote(name)+'&email='+urlquote(email)+'&'+u'timestamp='+str(dt)+'&hash='+generated_hash+'&debug=1'
+    url = settings.FRESHDESK_URL+'login/sso/?name='+urlquote(name)+'&email='+urlquote(email)+'&'+u'timestamp='+str(dt)+'&hash='+generated_hash
 
     return HttpResponseRedirect(url)

--- a/core/views.py
+++ b/core/views.py
@@ -21,6 +21,14 @@ from django.contrib.auth import password_validation
 from core.class_views import PleioBackupTokensView, PleioSessionListView, PleioProfileView
 from two_factor.views.profile import DisableView
 
+from django.http import Http404, HttpResponseRedirect
+from django.views.decorators.cache import never_cache
+from django.utils.encoding import iri_to_uri
+from django.utils.http import urlquote
+from django.core.exceptions import ImproperlyConfigured
+import hashlib
+import hmac
+from datetime import datetime
 
 def home(request):
     if request.user.is_authenticated():
@@ -208,3 +216,20 @@ def user_sessions_form(request):
     user_sessions = PleioSessionListView.as_view(template_name='security_pages.html')(request).context_data
 
     return user_sessions['object_list']
+
+@never_cache
+@login_required
+def freshdesk_sso(request):
+   
+    if not request.user:
+        raise Http404()
+
+    name = request.user.name
+    email = request.user.email
+    dt = int(datetime.utcnow().strftime("%s")) - 148
+
+    data = '{0}{1}{2}{3}'.format(name, settings.FRESHDESK_SECRET_KEY, email, dt)
+    generated_hash = hmac.new(settings.FRESHDESK_SECRET_KEY.encode(), data.encode(), hashlib.md5).hexdigest()
+    url = settings.FRESHDESK_URL+'login/sso/?name='+urlquote(name)+'&email='+urlquote(email)+'&'+u'timestamp='+str(dt)+'&hash='+generated_hash+'&debug=1'
+
+    return HttpResponseRedirect(url)

--- a/pleio_account/settings.py
+++ b/pleio_account/settings.py
@@ -181,6 +181,9 @@ LOGOUT_REDIRECT_URL = '/logout/'
 OIDC_USERINFO = 'pleio_account.oidc_provider_settings.userinfo'
 OIDC_EXTRA_SCOPE_CLAIMS = 'pleio_account.oidc_provider_settings.CustomScopeClaims'
 
+FRESHDESK_URL = 'https://gccollab.gctools-outilsgc.ca/'
+FRESHDESK_SECRET_KEY = ''
+
 ELGG_URL = 'https://gccollab.ca'
 
 PASSWORD_RESET_TIMEOUT_DAYS = 1

--- a/pleio_account/settings.py
+++ b/pleio_account/settings.py
@@ -182,7 +182,7 @@ OIDC_USERINFO = 'pleio_account.oidc_provider_settings.userinfo'
 OIDC_EXTRA_SCOPE_CLAIMS = 'pleio_account.oidc_provider_settings.CustomScopeClaims'
 
 FRESHDESK_URL = 'https://gccollab.gctools-outilsgc.ca/'
-FRESHDESK_SECRET_KEY = ''
+FRESHDESK_SECRET_KEY = os.getenv('FRESHDESK_SECRET_KEY', '')
 
 ELGG_URL = 'https://gccollab.ca'
 

--- a/pleio_account/urls.py
+++ b/pleio_account/urls.py
@@ -92,7 +92,8 @@ urls = [
     url(r'^api/users/me$', api_views.me, name='me'),
     url(r'^admin/', admin.site.urls),
     url(r'^$', views.home, name='home'),
-    url(r'^i18n/', include('django.conf.urls.i18n'))
+    url(r'^i18n/', include('django.conf.urls.i18n')),
+    url(r'^freshdesk/', views.freshdesk_sso, name='freshdesk_sso')
 ]
 
 tf_urls = [


### PR DESCRIPTION
Adds a new page to enable Single Sign-On within Freshdesk (https://github.com/gctools-outilsgc/concierge/issues/45). Although Freshdesk does not integrate directly with OpenID Connect, it can use a HMAC-MD5 hash to confirm accounts from Django using the logic explained here: https://support.freshdesk.com/support/solutions/articles/31166-single-sign-on-remote-authentication-in-freshdesk