### PR TITLE
Do not print passwords in plain text to the log.

### DIFF
--- a/pleio_account/password_validation.py
+++ b/pleio_account/password_validation.py
@@ -10,7 +10,6 @@ class CustomPasswordValidator(object):
         self.min_special_characters = special_characters
 
     def validate(self, password, user=None):
-        print(password)
         special_characters = "[~\!@#\$%\^&\*\(\)_\+{}\":;'\[\]]"
         errors = []
         


### PR DESCRIPTION
With the default logging setup, this print will result in every password entered ending up in the log in plain text.