### PR TITLE
Add ID of user in admin core user list

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -210,7 +210,7 @@ from django.contrib.auth.admin import UserAdmin
 class UserAdmin(UserAdmin):
     search_fields = ModelAdmin.search_fields = ('username', 'name', 'email',)
     list_filter = ModelAdmin.list_filter + ('is_active', 'is_admin',)
-    list_display = ModelAdmin.list_display + ('is_active',)
+    list_display = ModelAdmin.list_display + ('is_active','id',)
     filter_horizontal = ()
     ordering = ('-id', )
     fieldsets = add_fieldsets = (


### PR DESCRIPTION
By adding the ID, the helpdesk person will be able to link the account of the user to the GCCollab profil.

Fix #80 