### PR TITLE
Remove access to security question page when not login

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -141,7 +141,6 @@ def terms_of_use(request):
 
     return render(request, 'terms_of_use.html')
 
-
 def security_questions(request):
 
     #bring user back to start
@@ -215,6 +214,7 @@ def security_question(request):
     security_questions = {}
     return security_questions
 
+@login_required
 def set_security_question(request):
 
     form = ChooseSecurityQuestion()


### PR DESCRIPTION
Adding required login to security question page so not login user wont access the page.

related to https://zube.io/tbs-sct/gctools/c/4120