### PR TITLE
Fix for email not being sent when configured

### DIFF
--- a/core/backends.py
+++ b/core/backends.py
@@ -74,7 +74,7 @@ class SiteConfigEmailBackend(EmailBackend):
              **kwargs
         )
 
-    def send_messages(self, email_messages):
-        return len(list(email_messages))
+    #def send_messages(self, email_messages):
+    #    return len(list(email_messages))
 
 __all__ = ['SiteConfigEmailBackend']


### PR DESCRIPTION
# Bug
No email was being sent using the custom email backend.

## Problem in code
In the definition of the Email Backend the send_messages over ride function was a dummy function that was returning the length of an array to mock a successful send and not actually sending the emails.

## Solution
Removed the send_messages over ride function to inherit instead from SMTP parent.