### PR TITLE
When updated to Python 3.6 library calls were not updated

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -331,15 +331,15 @@ def freshdesk_sso(request):
 
     data = '{0}{1}{2}{3}'.format(name, config.FRESHDESK_SECRET_KEY, email, dt)
     generated_hash = hmac.new(
-        config.FRESHDESK_SECRET_KEY,
-        data,
+        config.FRESHDESK_SECRET_KEY.encode(),
+        data.encode(),
         hashlib.md5
     ).hexdigest()
 
     return HttpResponseRedirect(
         config.FRESHDESK_URL
         + 'login/sso/?'
-        + urllib.urlencode({
+        + urllib.parse.urlencode({
             'name': name,
             'email': email,
             'timestamp': str(dt),


### PR DESCRIPTION
When the Python version was updated to 3.6 the freskdesk function was still using legacy 2.7 syntax and libraries.