### PR TITLE
Breaking change in urlBase64Encode between django 1.1 a 2

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -53,7 +53,7 @@ class ResetPasswordRequestView(FormView):
                 for user in found_user:
                     c = {
                         'domain': request.META['HTTP_HOST'],
-                        'uid': urlsafe_base64_encode(force_bytes(user.pk)),
+                        'uid': urlsafe_base64_encode(force_bytes(user.pk)).decode(),
                         'user': user,
                         'token': default_token_generator.make_token(user),
                         'protocol': request.is_secure() and "https" or "http",
@@ -111,7 +111,7 @@ class ResetPasswordRequestView(FormView):
                     user.save()
                     c = {
                         'domain': request.META['HTTP_HOST'],
-                        'uid': urlsafe_base64_encode(force_bytes(user.pk)),
+                        'uid': urlsafe_base64_encode(force_bytes(user.pk)).decode(),
                         'user': user,
                         'token': default_token_generator.make_token(user),
                         'protocol': request.is_secure() and "https" or "http",


### PR DESCRIPTION
The hash for the UID generated for the password reset email was not being properly created and thus failing every time it was passed into the password reset confirm view.

This fixes Issue  #134