### PR TITLE
Lowercase usernames/emails

### DIFF
--- a/core/backends.py
+++ b/core/backends.py
@@ -35,7 +35,7 @@ class ElggBackend:
             if valid_user is True:
                 user = User.objects.create_user(
                     name=name,
-                    email=username,
+                    email=username.lower(),
                     password=password,
                     accepted_terms=True,
                     receives_newsletter=True

--- a/core/forms.py
+++ b/core/forms.py
@@ -202,7 +202,7 @@ class RegisterForm(forms.Form):
 
     def clean_email(self):
         # Get the emails
-        email = self.cleaned_data.get('email')
+        email = self.cleaned_data.get('email').lower()
 
         try:
             User.objects.get(email=email)
@@ -248,6 +248,8 @@ class UserProfileForm(forms.ModelForm):
     class Meta:
         model = User
         fields = ('name', 'email', 'receives_newsletter',)
+    def clean_email(self):
+        return self.cleaned_data.get('email').lower()
 
 
 class LabelledLoginForm(AuthenticationForm):
@@ -265,7 +267,7 @@ class LabelledLoginForm(AuthenticationForm):
         widget=forms.PasswordInput(attrs={'autocomplete': 'off'})
     )
     def clean(self):
-        username = self.cleaned_data.get('username')
+        username = self.cleaned_data.get('username').lower()
         password = self.cleaned_data.get('password')
 
         credentials={

--- a/core/views.py
+++ b/core/views.py
@@ -105,7 +105,7 @@ def profile(request):
         form = UserProfileForm(request.POST, request.FILES, instance=request.user)
         if form.is_valid():
             user = form.save()
-
+            form = UserProfileForm(instance=request.user)
     else:
         form = UserProfileForm(instance=request.user)
 


### PR DESCRIPTION
Usernames/emails now save as lowercase when making changes or creating a user. 

A script will need to be written to change registered user's emails to lowercase to match this new format.