### PR TITLE
add rabbitmq call

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -19,7 +19,7 @@ from .login_session_helpers import (
     get_device,
     get_lat_lon
 )
-# from .valid_new_user import mq_newuser
+from .valid_new_user import mq_newuser
 
 
 class Manager(BaseUserManager):
@@ -38,6 +38,7 @@ class Manager(BaseUserManager):
         user.receives_newsletter = receives_newsletter
 
         user.save(using=self._db)
+
         return user
 
     def create_superuser(self, email, name, password):
@@ -150,12 +151,13 @@ class User(AbstractBaseUser):
 
             self.is_active = True
             self.save()
+
             # valid_user is the routing followed by name, email and id
-            # mq_newuser('user.new', json.dumps({
-            #    'name': self.name,
-            #    'email': self.email,
-            #    'id': self.id
-            # }))
+            mq_newuser('user.new', json.dumps({
+               'name': self.name,
+               'email': self.email,
+               'id': self.id
+            }))
             return self
 
         except (signing.BadSignature, User.DoesNotExist):
@@ -262,6 +264,16 @@ class UserAdmin(UserAdmin):
             )
         }),
     )
+
+    def save_model(self,request, obj, form, change):
+        if form.instance.is_active == True :
+            # valid_user is the routing followed by name, email and id
+            mq_newuser('user.new', json.dumps({
+               'name': obj.name,
+               'email': obj.email,
+               'id': obj.id
+            }))
+        obj.save()
 
 
 class PreviousLogin(models.Model):

--- a/core/models.py
+++ b/core/models.py
@@ -156,7 +156,7 @@ class User(AbstractBaseUser):
             mq_newuser('user.new', json.dumps({
                'name': self.name,
                'email': self.email,
-               'id': self.id
+               'gcID': self.id
             }))
             return self
 
@@ -271,7 +271,7 @@ class UserAdmin(UserAdmin):
             mq_newuser('user.new', json.dumps({
                'name': obj.name,
                'email': obj.email,
-               'id': obj.id
+               'gcID': obj.id
             }))
         obj.save()
 


### PR DESCRIPTION
**What I change**
Uncomment the rabbitMQ call when a user activate an account
Adding the rabbitmq call when an admin activate an account

The information send to rabbitmq is: username, email and id
related to: https://zube.io/tbs-sct/gctools/c/5815

**How to test:**
Make sure you add you rabbitmq info in setting.py
Make sure you connect concierge to a smtp email service (using constance/config in the admin panel)

- Create a new user using Register form. Then valid your account using the link in your email. It should send info to rabbitmq

- After, using the admin panel, desactivate the user account and reactivate. Once activate, it should send info to rabbitmq