### PR TITLE
add rabbitmq call to admin and remove rabbitmq setting

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -262,6 +262,16 @@ class UserAdmin(UserAdmin):
         }),
     )
 
+    def save_model(self,request, obj, form, change):
+        if form.instance.is_active == True :
+            # valid_user is the routing followed by name, email and id
+            service_mesh_message('user.new', json.dumps({
+                'name': obj.name,
+                'email': obj.email,
+                'gcID': obj.id
+            }))
+        obj.save()
+
 
 class PreviousLogin(models.Model):
     user = models.ForeignKey(

--- a/pleio_account/settings.py
+++ b/pleio_account/settings.py
@@ -252,11 +252,6 @@ LOGGING = {
     },
 }
 
-# RabbitMq settings
-MQ_USER = ""
-MQ_PASSWORD = ""
-MQ_CONNECTION = ""
-
 # You can introspect any apps tokens
 OIDC_INTROSPECTION_VALIDATE_AUDIENCE_SCOPE = False
 


### PR DESCRIPTION
**What I change**
Remove rabbitmq setting because it was replace by the setting in constance
Adding the rabbitmq call when an admin activate an account

The information send to rabbitmq is: username, email and id
related to: https://zube.io/tbs-sct/gctools/c/5815

**How to test:**
Make sure you add your rabbitmq info into constance
Make sure you connect concierge to a smtp email service using constance

- Create a new user using Register form. Then valid your account using the link in your email. It should send info to rabbitmq

- After, using the admin panel, desactivate the user account and reactivate. Once activate, it should send info to rabbitmq