### PR TITLE
Prevent No module named 'ipware.ip2'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,3 +23,4 @@ psycopg2==2.7
 uWSGI==2.0.15
 pika==0.12.0
 django-redis==4.10.0
+django-ipware==2.1.0


### PR DESCRIPTION
When installing concierge using docker, the error "No module named 'ipware.ip2'"

The way to fix it is by adding ipware to the requirements.