### PR TITLE
Display app URLs in both English and French

### DIFF
--- a/core/forms.py
+++ b/core/forms.py
@@ -33,7 +33,7 @@ class PasswordResetRequestForm(forms.Form):
 
 class ResetPasswordRequestView(FormView):
     template_name = "registration/password_reset.html"
-    success_url = '/password_reset/done/'
+    success_url = '/password_reset-reinitialiser_le_mot_de_passe/done-fait/'
     form_class = PasswordResetRequestForm
 
     @staticmethod

--- a/core/templates/base_account.html
+++ b/core/templates/base_account.html
@@ -58,7 +58,7 @@
                 <ul class="account-menu__list">
 
                     <li>
-                        {% if request.path == '/profile/' %}
+                        {% if request.path == '/profile-profil/' %}
                             <a href="{% url 'profile' %}" class="account-menu__list current">
                         {% else %}
                             <a href="{% url 'profile' %}">
@@ -71,7 +71,7 @@
                         </a>
                     </li>
                     <li>
-                        {% if request.path >= '/securitypages/' %}
+                        {% if request.path >= '/securitypages-pagesdesecurite/' %}
                             <a href="{% url 'security_pages' %}" class="account-menu__list current">
                         {% else %}
                             <a href="{% url 'security_pages' %}">

--- a/core/templates/base_account.html
+++ b/core/templates/base_account.html
@@ -71,7 +71,7 @@
                         </a>
                     </li>
                     <li>
-                        {% if request.path >= '/securitypages-pagesdesecurite/' %}
+                        {% if request.path >= '/securitypages-pagessurlasecurite/' %}
                             <a href="{% url 'security_pages' %}" class="account-menu__list current">
                         {% else %}
                             <a href="{% url 'security_pages' %}">

--- a/core/templates/registration/password_reset_questions.html
+++ b/core/templates/registration/password_reset_questions.html
@@ -23,7 +23,7 @@
       </ul>
     {% endif %}
 
-    <form method="post" action="/password_reset/questions/" class="ui form" autocomplete="off">
+    <form method="post" action="/password_reset-reinitialiser_le_mot_de_passe/questions/" class="ui form" autocomplete="off">
       {% csrf_token %}
       <fieldset>
           <input type="hidden"  id=id_question_email name="question_email" aria-label="email" value="{{ request.session.email }}">

--- a/core/templates/security_pages/change_password.html
+++ b/core/templates/security_pages/change_password.html
@@ -3,7 +3,7 @@
 
 
 
-<form method="post" action="/securitypages/change-password/" class="ui form card">
+<form method="post" action="/securitypages-pagesdesecurite/change-password/" class="ui form card">
     <div class="account__cards content">
       <h3 class="card__title ___addpadding-side header">{% trans "Reset password" %}</h3>
       <input type="hidden" name="page_action" aria-label="page action" value="ChangePassword" />

--- a/core/templates/security_pages/change_password.html
+++ b/core/templates/security_pages/change_password.html
@@ -3,7 +3,7 @@
 
 
 
-<form method="post" action="/securitypages-pagesdesecurite/change-password/" class="ui form card">
+<form method="post" action="/securitypages-pagessurlasecurite/change-password/" class="ui form card">
     <div class="account__cards content">
       <h3 class="card__title ___addpadding-side header">{% trans "Reset password" %}</h3>
       <input type="hidden" name="page_action" aria-label="page action" value="ChangePassword" />

--- a/core/templates/security_pages/two_factor_authorization.html
+++ b/core/templates/security_pages/two_factor_authorization.html
@@ -29,7 +29,7 @@
 
     {% if 2FA.state == 'setup' %}
 
-        <form method="post" action="/securitypages/2fa-setupnext/" class="ui form">
+        <form method="post" action="/securitypages-pagesdesecurite/2fa-setupnext/" class="ui form">
             <div class="account__cards ui card">
                   <div class="content">
           		      <h3 class="card__title ___addpadding-side header">{% trans "Enable two-factor authentication" %}</h3>
@@ -100,7 +100,7 @@
 
     {% if 2FA.state == 'disable' %}
 
-        <form method="post" action="/securitypages/2fa-disableconfirm/" class="ui form">
+        <form method="post" action="/securitypages-pagesdesecurite/2fa-disableconfirm/" class="ui form">
           <div class="account__cards ui card">
               <div class=" ___nopadding content">
                     {% csrf_token %}
@@ -154,7 +154,7 @@
                 </div>
               </div>
               <div class="extra content">
-                <form method="post" action="/securitypages/2fa-setup/">
+                <form method="post" action="/securitypages-pagesdesecurite/2fa-setup/">
                     <div class="card__action ___addpadding-side">
                         {% csrf_token %}
                         <button name="2fa-setup" type="submit" class="ui button right floated primary">{% trans "Enable" %}</button>

--- a/core/templates/security_pages/two_factor_authorization.html
+++ b/core/templates/security_pages/two_factor_authorization.html
@@ -21,7 +21,7 @@
                 </p>
             </div>
             <div class="card__action ___addpadding-side extra content">
-                <a href="{% url 'security_pages' page_action='2fa-showcodes' %}" class="button ___clear ui button right floated primary">{% trans "Show codes" %}</a>
+                <a href="{% url 'security_pages' page_action='2fa_showcodes-a2f_afficherlescodes' %}" class="button ___clear ui button right floated primary">{% trans "Show codes" %}</a>
             </div>
         </div>
         {% endif %}
@@ -29,7 +29,7 @@
 
     {% if 2FA.state == 'setup' %}
 
-        <form method="post" action="/securitypages-pagesdesecurite/2fa-setupnext/" class="ui form">
+        <form method="post" action="/securitypages-pagessurlasecurite/2fa_setupnext-a2f_configurationsuivante/" class="ui form">
             <div class="account__cards ui card">
                   <div class="content">
           		      <h3 class="card__title ___addpadding-side header">{% trans "Enable two-factor authentication" %}</h3>
@@ -64,7 +64,7 @@
     {% endif %}
 
     {% if 2FA.state == 'codes' %}
-    <form method="post" class="ui form" action="." "page_action=2fa-generatecodes">{% csrf_token %}{{ form }}
+    <form method="post" class="ui form" action="." "page_action=2fa-generatecodes-a2f_genererdescodes">{% csrf_token %}{{ form }}
         <div class="account__cards ui card">
             <div class="___nopadding content">
               <h3 class="card__title ___addpadding-side header">{% trans "Backup tokens" %}</h3>
@@ -100,7 +100,7 @@
 
     {% if 2FA.state == 'disable' %}
 
-        <form method="post" action="/securitypages-pagesdesecurite/2fa-disableconfirm/" class="ui form">
+        <form method="post" action="/securitypages-pagessurlasecurite/2fa_disableconfirm-a2f_désactiverconfirmer/" class="ui form">
           <div class="account__cards ui card">
               <div class=" ___nopadding content">
                     {% csrf_token %}
@@ -139,7 +139,7 @@
                 </div>
               </div>
                 <div class="card__action ___addpadding-side extra content">
-                    <a href="{% url 'security_pages' page_action='2fa-disable' %}" class="button ___clear ui button negative right floated">{% trans "Disable" %}</a>
+                    <a href="{% url 'security_pages' page_action='2fa_disable-a2f_desactiver' %}" class="button ___clear ui button negative right floated">{% trans "Disable" %}</a>
                 </div>
             {% else %}
             <div class="___nopadding content">
@@ -154,7 +154,7 @@
                 </div>
               </div>
               <div class="extra content">
-                <form method="post" action="/securitypages-pagesdesecurite/2fa-setup/">
+                <form method="post" action="/securitypages-pagessurlasecurite/2fa_setup-a2f_configuration/">
                     <div class="card__action ___addpadding-side">
                         {% csrf_token %}
                         <button name="2fa-setup" type="submit" class="ui button right floated primary">{% trans "Enable" %}</button>

--- a/core/templates/security_pages/two_factor_authorization.html
+++ b/core/templates/security_pages/two_factor_authorization.html
@@ -64,7 +64,7 @@
     {% endif %}
 
     {% if 2FA.state == 'codes' %}
-    <form method="post" class="ui form" action="." "page_action=2fa-generatecodes-a2f_genererdescodes">{% csrf_token %}{{ form }}
+    <form method="post" class="ui form" action="." "page_action=2fa_generatecodes-a2f_genererdescodes">{% csrf_token %}{{ form }}
         <div class="account__cards ui card">
             <div class="___nopadding content">
               <h3 class="card__title ___addpadding-side header">{% trans "Backup tokens" %}</h3>
@@ -100,7 +100,7 @@
 
     {% if 2FA.state == 'disable' %}
 
-        <form method="post" action="/securitypages-pagessurlasecurite/2fa_disableconfirm-a2f_désactiverconfirmer/" class="ui form">
+        <form method="post" action="/securitypages-pagessurlasecurite/2fa_disableconfirm-a2f_desactiverconfirmer/" class="ui form">
           <div class="account__cards ui card">
               <div class=" ___nopadding content">
                     {% csrf_token %}

--- a/core/views.py
+++ b/core/views.py
@@ -85,7 +85,6 @@ def register(request):
 
     return render(request, 'register.html', {'form': form})
 
-
 def register_complete(request):
     return render(request, 'register_complete.html')
 
@@ -193,8 +192,8 @@ def security_questions(request):
         if form.is_valid():
             del request.session['email']
             del request.session['picks']
-            return redirect(request.scheme + '://' + request.META['HTTP_HOST'] + '/reset/' +
-                (urlsafe_base64_encode(force_bytes(user.pk))).decode('utf-8') + '/' +
+            return redirect(request.scheme + '://' + request.META['HTTP_HOST'] + '/reset-reinitialiser/' +
+                urlsafe_base64_encode(force_bytes(user.pk)) + '/' +
                 default_token_generator.make_token(user)
              )
 
@@ -277,7 +276,7 @@ def set_security_question(request):
 
 def two_factor_form(request, page_action):
     two_factor_authorization =  {}
-    if page_action == '2fa-setup':
+    if page_action == '2fa_setup-a2f_configuration':
         key = random_hex(20).decode('ascii')
         rawkey = unhexlify(key.encode('ascii'))
         b32key = b32encode(rawkey).decode('utf-8')
@@ -291,7 +290,7 @@ def two_factor_form(request, page_action):
         })
         two_factor_authorization['state'] = 'setup'
 
-    elif page_action == '2fa-setupnext':
+    elif page_action == '2fa_setupnext-a2f_configurationsuivante':
         key = request.session.get('tf_key')
         form = PleioTOTPDeviceForm(data=request.POST, key=key, user=request.user)
         if form.is_valid():
@@ -304,22 +303,22 @@ def two_factor_form(request, page_action):
             two_factor_authorization['QR_URL'] = reverse('two_factor:qr')
             two_factor_authorization['state'] = 'setup'
 
-    elif page_action == '2fa-disable':
+    elif page_action == '2fa_disable-a2f_desactiver':
         two_factor_authorization = DisableView.as_view(template_name='security_pages.html')(request).context_data
         two_factor_authorization['state'] = 'disable'
 
-    elif page_action == '2fa-disableconfirm':
+    elif page_action == '2fa_disableconfirm-a2f_désactiverconfirmer':
         two_factor_authorization = DisableView.as_view(template_name='security_pages.html')(request)
         two_factor_authorization['state'] = 'default'
         two_factor_authorization['show_state'] = 'true'
 
-    elif page_action == '2fa-showcodes':
+    elif page_action == '2fa_showcodes-a2f_afficherlescodes':
         two_factor_authorization = PleioBackupTokensView.as_view(template_name='backup_tokens.html')(request).context_data
         two_factor_authorization['default_device'] = 'true'
         two_factor_authorization['state'] = 'codes'
         two_factor_authorization['show_state'] = 'true'
 
-    elif page_action == '2fa-generatecodes':
+    elif page_action == '2fa-generatecodes-a2f_genererdescodes':
         two_factor_authorization = PleioBackupTokensView.as_view(template_name='security_pages.html')(request).context_data
         two_factor_authorization['default_device'] = 'true'
         two_factor_authorization['show_state'] = 'true'

--- a/core/views.py
+++ b/core/views.py
@@ -307,7 +307,7 @@ def two_factor_form(request, page_action):
         two_factor_authorization = DisableView.as_view(template_name='security_pages.html')(request).context_data
         two_factor_authorization['state'] = 'disable'
 
-    elif page_action == '2fa_disableconfirm-a2f_désactiverconfirmer':
+    elif page_action == '2fa_disableconfirm-a2f_desactiverconfirmer':
         two_factor_authorization = DisableView.as_view(template_name='security_pages.html')(request)
         two_factor_authorization['state'] = 'default'
         two_factor_authorization['show_state'] = 'true'
@@ -318,7 +318,7 @@ def two_factor_form(request, page_action):
         two_factor_authorization['state'] = 'codes'
         two_factor_authorization['show_state'] = 'true'
 
-    elif page_action == '2fa-generatecodes-a2f_genererdescodes':
+    elif page_action == '2fa_generatecodes-a2f_genererdescodes':
         two_factor_authorization = PleioBackupTokensView.as_view(template_name='security_pages.html')(request).context_data
         two_factor_authorization['default_device'] = 'true'
         two_factor_authorization['show_state'] = 'true'

--- a/pleio_account/settings.py
+++ b/pleio_account/settings.py
@@ -228,8 +228,8 @@ GEOIP_PATH = os.path.join(BASE_DIR, 'assets/geopip2/')
 MEDIA_URL = '/media/'
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media/')
 
-LOGIN_URL = '/login/'
-LOGIN_REDIRECT_URL = '/profile/'
+LOGIN_URL = '/login-ouverturedesession/'
+LOGIN_REDIRECT_URL = '/profile-profil/'
 LOGOUT_REDIRECT_URL = '/logout/'
 
 OIDC_USERINFO = 'pleio_account.oidc_provider_settings.userinfo'

--- a/pleio_account/urls.py
+++ b/pleio_account/urls.py
@@ -14,7 +14,8 @@ from core import views, forms
 from core.class_views import (
     PleioLoginView,
     PleioSessionDeleteView,
-    PleioSessionDeleteOtherView
+    PleioSessionDeleteOtherView,
+    i18nPasswordResetConfirmView
 )
 from axes.decorators import axes_dispatch
 
@@ -62,22 +63,22 @@ def decorated_includes(func, includes):
 urlpatterns = [
     path('register-sinscrire/', views.register, name='register'),
     path(
-        'register-sinscrire/complete/',
+        'register-sinscrire/complete-termine/',
         views.register_complete,
         name='register_complete'
     ),
     path(
-        'register-sinscrire/activate/<activation_token>/',
+        'register-sinscrire/activate-activer/<activation_token>/',
         views.register_activate,
         name='register_activate'
     ),
     path('termsofuse/', views.terms_of_use, name='terms_of_use'),
     path(
-        'securitypages-pagesdesecurite/<page_action>/',
+        'securitypages-pagessurlasecurite/<page_action>/',
         views.security_pages,
         name='security_pages'
     ),
-    path('securitypages-pagesdesecurite/', views.security_pages, name='security_pages'),
+    path('securitypages-pagessurlasecurite/', views.security_pages, name='security_pages'),
     path(
         'securityquestions-questionsdesecurite/',
         views.set_security_question,
@@ -127,12 +128,12 @@ urlpatterns = [
     # Overriding some of the built-in contrib.auth views to use our templates
     # instead.
     path(
-        'password_reset/',
+        'password_reset-reinitialiser_le_mot_de_passe/',
         forms.ResetPasswordRequestView.as_view(),
         name='password_reset'
     ),
     path(
-        'password_reset/done/',
+        'password_reset-reinitialiser_le_mot_de_passe/done-fait/',
         auth_views.PasswordResetDoneView.as_view(),
         {
             'template_name': 'registration/password_reset_done.html'
@@ -140,25 +141,22 @@ urlpatterns = [
         name='password_reset_done'
     ),
     path(
-        'password_reset/questions/',
+        'password_reset-reinitialiser_le_mot_de_passe/questions/',
         views.security_questions,
         name='password_reset_questions'
     ),
     path(
-        'password_reset/notactive/',
+        'password_reset-reinitialiser_le_mot_de_passe/notactive-pasactif/',
         views.not_active_profile,
         name='password_reset_not_active'
     ),
     path(
-        'reset/<uidb64>/<token>/',
-        auth_views.PasswordResetConfirmView.as_view(),
-        {
-            'template_name': 'registration/password_reset_confirm.html'
-        },
+        'reset-reinitialiser/<uidb64>/<token>/',
+        view=i18nPasswordResetConfirmView.as_view(),
         name='password_reset_confirm'
     ),
     path(
-        'reset/done/',
+        'reset-reinitialiser/done-fait/',
         auth_views.PasswordResetCompleteView.as_view(),
         {
             'template_name': 'registration/password_reset_complete.html'

--- a/pleio_account/urls.py
+++ b/pleio_account/urls.py
@@ -5,6 +5,7 @@ from django.views.decorators.clickjacking import xframe_options_exempt
 from django.urls import path, URLPattern, URLResolver
 from django.contrib import admin
 from django.views.i18n import JavaScriptCatalog
+from django.views.generic import RedirectView
 from oauth2_provider import views as oauth2_views
 from two_factor.urls import urlpatterns as tf_urls
 
@@ -59,36 +60,36 @@ def decorated_includes(func, includes):
 
 
 urlpatterns = [
-    path('register/', views.register, name='register'),
+    path('register-sinscrire/', views.register, name='register'),
     path(
-        'register/complete/',
+        'register-sinscrire/complete/',
         views.register_complete,
         name='register_complete'
     ),
     path(
-        'register/activate/<activation_token>/',
+        'register-sinscrire/activate/<activation_token>/',
         views.register_activate,
         name='register_activate'
     ),
     path('termsofuse/', views.terms_of_use, name='terms_of_use'),
     path(
-        'securitypages/<page_action>/',
+        'securitypages-pagesdesecurite/<page_action>/',
         views.security_pages,
         name='security_pages'
     ),
-    path('securitypages/', views.security_pages, name='security_pages'),
+    path('securitypages-pagesdesecurite/', views.security_pages, name='security_pages'),
     path(
-        'security-questions/',
+        'securityquestions-questionsdesecurite/',
         views.set_security_question,
         name='set-questions'
     ),
     path(
-        'login/',
-        axes_dispatch(PleioLoginView.as_view()),
+        'login-ouverturedesession/',
+        axes_dispatch(PleioLoginView.as_view(redirect_authenticated_user=True)),
         name='login'
     ),
     path('logout/', views.logout, name='logout'),
-    path('profile/', views.profile, name='profile'),
+    path('profile-profil/', views.profile, name='profile'),
     path(
         'accept_previous_logins/<acceptation_token>/',
         views.accept_previous_login,

--- a/pleio_account/urls.py
+++ b/pleio_account/urls.py
@@ -5,7 +5,6 @@ from django.views.decorators.clickjacking import xframe_options_exempt
 from django.urls import path, URLPattern, URLResolver
 from django.contrib import admin
 from django.views.i18n import JavaScriptCatalog
-from django.views.generic import RedirectView
 from oauth2_provider import views as oauth2_views
 from two_factor.urls import urlpatterns as tf_urls
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ django-filter==2.1.0
 django-formtools==2.1
 django-oauth-toolkit==1.2.0
 django-oidc-provider==0.7.0
-django-otp==0.5.1
+django-otp==0.6.0
 django-phonenumber-field==1.3.0
 django-picklefield==2.0
 django-user-sessions==1.7.1


### PR DESCRIPTION
App URLs now display both languages. See below for changes

Before| After
--- | --- 
/login | /login-ouverturedesession 
/register | /register-sinscrire 
/register/complete | /register-sinscrire/complete-termine 
/register/activate | /register-sinscrire/activate-activer 
/password-reset | /password_reset-reinitialiser_le_mot_de_passe 
/password-rest/done | /password_reset-reinitialiser_le_mot_de_passe/done-fait 
/password-reset/questions | /password_reset-reinitialiser_le_mot_de_passe/questions 
/password-reset/notactive | /password_reset-reinitialiser_le_mot_de_passe/notactive-pasactif 
/reset/NA/set-password | /reset-reinitialiser/NA/set_password-creer_un_mot_de_passe
/reset/done | /reset-reinitialiser/done-fait 
/profile | /profile-profil 
/securitypages |  /securitypages-pagessurlasecurite
/securityquestions | /securityquestions-questionsdesecurite 
/securitypages/2fa-setup | /securitypages-pagessurlasecurite/2fa_setup-a2f_configuration 
/securitypages/2fa-setupnext | /securitypages-pagessurlasecurite/2fa_setupnext-a2f_configurationsuivante  
/securitypages/2fa-disable | /securitypages-pagessurlasecurite/2fa_disable-a2f_desactiver  
/securitypages/2fa-disableconfirm | /securitypages-pagessurlasecurite/2fa_disableconfirm-a2f_desactiverconfirmer  
/securitypages/2fa-showcodes | /securitypages-pagessurlasecurite/2fa_showcodes-a2f_afficherlescodes  
/securitypages/2fa-generatecodes | /securitypages-pagessurlasecurite/2fa_generatecodes-a2f_genererdescodes  

A few app action URLs were not included since the user never stops on these pages